### PR TITLE
fix max_time off-by-one error and max_nterms calculation

### DIFF
--- a/dtm/main.c
+++ b/dtm/main.c
@@ -123,19 +123,17 @@ void fit_dtm(int min_time, int max_time)
 	     && min_time >= 0
 	     && max_time < data_full->len);
       data_subset = (corpus_seq_t*) malloc(sizeof(corpus_seq_t));
-      data_subset->len = max_time - min_time + 1;
+      data_subset->len = max_time - min_time;
       data_subset->nterms = data_full->nterms;
       data_subset->corpus = (corpus_t**) malloc(
         sizeof(corpus_t*) * data_subset->len);
-      int max_nterms = 0;
       int ndocs = 0;
       for (int i=min_time; i < max_time; ++i) {
 	corpus_t* corpus = data_full->corpus[i];
-	max_nterms = max_nterms > corpus->nterms ? max_nterms : corpus->nterms;
 	data_subset->corpus[i - min_time] = corpus;
 	ndocs += corpus->ndocs;
       }
-      data_subset->max_nterms = max_nterms;
+      data_subset->max_nterms = compute_max_nterms(data_subset);
       data_subset->ndocs = ndocs;
     } else {
       // Use the entire dataset.
@@ -226,7 +224,7 @@ int main(int argc, char* argv[])
     // mode for fitting a dynamic topic model
 
     if (FLAGS_mode == "fit") {
-      fit_dtm(0, FLAGS_heldout_time - 1);
+      fit_dtm(0, FLAGS_heldout_time);
     }
 
     // mode for analyzing documents through time according to a DTM


### PR DESCRIPTION
Previously, trying to use the heldout_time option caused a segmentation fault. It looks as though in some parts of the source code, the training set was built using times [min_time, max_time-2], when it should use [min_time, max_time-1]. This is fixed by adding 1 in a couple of places.

The "max_nterms" property of data_subset was also improperly set, causing an error later on. This is fixed using the "compute_max_nterms" function defined elsewhere.

With these changes, the dtm model properly runs with the heldout_time argument and outputs a file containing the log likelihoods the documents as heldout_time.